### PR TITLE
Separated an Interface Project with some Default Implementations from…

### DIFF
--- a/Main/Source/NMemory.Test/NMemory.Test.csproj
+++ b/Main/Source/NMemory.Test/NMemory.Test.csproj
@@ -94,8 +94,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NMemory\NMemory.csproj">
-      <Project>{E95EF85F-FAC7-476E-8333-2D835BD41BD9}</Project>
+      <Project>{e95ef85f-fac7-476e-8333-2d835bd41bd9}</Project>
       <Name>NMemory</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NMemory\NMemory.Interface.csproj">
+      <Project>{0ae29c99-7824-4f13-bc92-b2c71ab60cea}</Project>
+      <Name>NMemory.Interface</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Main/Source/NMemory.sln
+++ b/Main/Source/NMemory.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NMemory", "NMemory\NMemory.csproj", "{E95EF85F-FAC7-476E-8333-2D835BD41BD9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NMemory.Test", "NMemory.Test\NMemory.Test.csproj", "{D877B580-57C2-44E6-98DB-0791D1F1DD64}"
@@ -19,25 +21,75 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E24775
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NMemory.Interface", "NMemory\NMemory.Interface.csproj", "{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}"
+EndProject
 Global
-	GlobalSection(TestCaseManagementSettings) = postSolution
-		CategoryFile = NMemory.vsmdi
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_net40|Any CPU = Debug_net40|Any CPU
+		Debug_net40|x86 = Debug_net40|x86
+		Debug_net45|Any CPU = Debug_net45|Any CPU
+		Debug_net45|x86 = Debug_net45|x86
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release_net40|Any CPU = Release_net40|Any CPU
+		Release_net40|x86 = Release_net40|x86
+		Release_net45|Any CPU = Release_net45|Any CPU
+		Release_net45|x86 = Release_net45|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug_net40|Any CPU.ActiveCfg = Debug|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug_net40|x86.ActiveCfg = Debug|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug_net45|Any CPU.ActiveCfg = Debug|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug_net45|x86.ActiveCfg = Debug|Any CPU
 		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release_net40|Any CPU.ActiveCfg = Release|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release_net40|x86.ActiveCfg = Release|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release_net45|Any CPU.ActiveCfg = Release|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release_net45|x86.ActiveCfg = Release|Any CPU
 		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E95EF85F-FAC7-476E-8333-2D835BD41BD9}.Release|x86.ActiveCfg = Release|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug_net40|Any CPU.ActiveCfg = Debug|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug_net40|x86.ActiveCfg = Debug|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug_net45|Any CPU.ActiveCfg = Debug|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug_net45|x86.ActiveCfg = Debug|Any CPU
 		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release_net40|Any CPU.ActiveCfg = Release|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release_net40|x86.ActiveCfg = Release|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release_net45|Any CPU.ActiveCfg = Release|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release_net45|x86.ActiveCfg = Release|Any CPU
 		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D877B580-57C2-44E6-98DB-0791D1F1DD64}.Release|x86.ActiveCfg = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug_net40|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug_net40|Any CPU.Build.0 = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug_net40|x86.ActiveCfg = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug_net45|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug_net45|Any CPU.Build.0 = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug_net45|x86.ActiveCfg = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release_net40|Any CPU.ActiveCfg = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release_net40|Any CPU.Build.0 = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release_net40|x86.ActiveCfg = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release_net45|Any CPU.ActiveCfg = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release_net45|Any CPU.Build.0 = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release_net45|x86.ActiveCfg = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = NMemory.vsmdi
 	EndGlobalSection
 EndGlobal

--- a/Main/Source/NMemory/Common/DatabaseMembers.cs
+++ b/Main/Source/NMemory/Common/DatabaseMembers.cs
@@ -31,7 +31,7 @@ namespace NMemory.Common
     using NMemory.Tables;
     using NMemory.Utilities;
 
-    internal static class DatabaseMembers
+	public static class DatabaseMembers
     {
         public static PropertyInfo Database_Tables
         {

--- a/Main/Source/NMemory/Common/DynamicMethodBuilder.cs
+++ b/Main/Source/NMemory/Common/DynamicMethodBuilder.cs
@@ -29,9 +29,9 @@ namespace NMemory.Common
     using System.Reflection;
     using System.Reflection.Emit;
 
-    internal delegate TObject DynamicPropertySetter<TObject>(TObject obj, params object[] args);
+    public delegate TObject DynamicPropertySetter<TObject>(TObject obj, params object[] args);
 
-    internal static class DynamicMethodBuilder
+    public static class DynamicMethodBuilder
     {
         public static Action<TObject, TValue> CreateSinglePropertySetter<TObject, TValue>(PropertyInfo member)
         {

--- a/Main/Source/NMemory/Common/ExpressionHelper.cs
+++ b/Main/Source/NMemory/Common/ExpressionHelper.cs
@@ -32,7 +32,7 @@ namespace NMemory.Common
     using NMemory.Indexes;
     using NMemory.StoredProcedures;
 
-    internal static class ExpressionHelper
+	public static class ExpressionHelper
     {
         public static MemberExpression FindMemberExpression(Expression expression)
         {

--- a/Main/Source/NMemory/Common/IEntityMemberInfoServicesProvider`2.cs
+++ b/Main/Source/NMemory/Common/IEntityMemberInfoServicesProvider`2.cs
@@ -24,7 +24,7 @@
 
 namespace NMemory.Common
 {
-    interface IEntityMemberInfoServicesProvider<TEntity, TMember>
+    public interface IEntityMemberInfoServicesProvider<TEntity, TMember>
     {
         IEntityMemberInfoServices<TEntity, TMember> EntityMemberInfoServices { get; }
     }

--- a/Main/Source/NMemory/Common/KeyExpressionHelper.cs
+++ b/Main/Source/NMemory/Common/KeyExpressionHelper.cs
@@ -29,7 +29,7 @@ namespace NMemory.Common
     using System.Reflection;
     using NMemory.Indexes;
 
-    internal static class KeyExpressionHelper
+	public static class KeyExpressionHelper
     {
         public static Expression<Func<TKey, bool>> CreateKeyEmptinessDetector<TEntity,TKey>(     
             IKeyInfoHelper helper)

--- a/Main/Source/NMemory/Common/ReflectionHelper.cs
+++ b/Main/Source/NMemory/Common/ReflectionHelper.cs
@@ -32,7 +32,7 @@ namespace NMemory.Common
     using System.Reflection;
     using System.Runtime.CompilerServices;
 
-    internal class ReflectionHelper
+    public class ReflectionHelper
     {
         public static Type GetMemberType(MemberInfo member)
         {

--- a/Main/Source/NMemory/Common/TupleTypeHelper.cs
+++ b/Main/Source/NMemory/Common/TupleTypeHelper.cs
@@ -26,7 +26,7 @@ namespace NMemory.Common
 {
     using System;
 
-    internal class TupleTypeHelper
+    public class TupleTypeHelper
     {
         public static readonly int LargeTupleSize = 8;
 

--- a/Main/Source/NMemory/Common/Visitors/EntityTypeSearchVisitor.cs
+++ b/Main/Source/NMemory/Common/Visitors/EntityTypeSearchVisitor.cs
@@ -31,7 +31,7 @@ namespace NMemory.Common.Visitors
     using NMemory.Indexes;
     using NMemory.Tables;
 
-    internal class EntityTypeSearchVisitor : ExpressionVisitor
+	public class EntityTypeSearchVisitor : ExpressionVisitor
     {
         private HashSet<Type> entityTypes;
 

--- a/Main/Source/NMemory/Concurrency/Locks/LightweightSpinLock.cs
+++ b/Main/Source/NMemory/Concurrency/Locks/LightweightSpinLock.cs
@@ -30,7 +30,7 @@ namespace NMemory.Concurrency.Locks
     using System.Text;
     using System.Threading;
 
-    internal class LightweightSpinLock
+    public class LightweightSpinLock
     {
         private static readonly int ProcessorCount = Environment.ProcessorCount; 
         private int held;
@@ -59,7 +59,7 @@ namespace NMemory.Concurrency.Locks
             this.held = 0;
         }
 
-        internal static void SpinWait(ref int retry)
+		public static void SpinWait(ref int retry)
         {
             if (retry < 10 && ProcessorCount > 1)
             {

--- a/Main/Source/NMemory/Constraints/TimestampConstraint.cs
+++ b/Main/Source/NMemory/Constraints/TimestampConstraint.cs
@@ -29,7 +29,7 @@ namespace NMemory.Constraints
     using NMemory.Data;
     using NMemory.Execution;
 
-    internal class TimestampConstraint<TEntity> : ConstraintBase<TEntity, Timestamp>
+    public class TimestampConstraint<TEntity> : ConstraintBase<TEntity, Timestamp>
     {
         public TimestampConstraint(Expression<Func<TEntity, Timestamp>> propertySelector) 
             : base(propertySelector)

--- a/Main/Source/NMemory/DataStructures/Hashtable.cs
+++ b/Main/Source/NMemory/DataStructures/Hashtable.cs
@@ -26,10 +26,8 @@ namespace NMemory.DataStructures
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
 
-    public class Hashtable<TKey, TEntity> : IDataStructure<TKey, TEntity>
+	public class Hashtable<TKey, TEntity> : IDataStructure<TKey, TEntity>
     {
         private Dictionary<TKey, List<TEntity>> inner;
 

--- a/Main/Source/NMemory/DataStructures/Internal/Trees/RedBlackTree.cs
+++ b/Main/Source/NMemory/DataStructures/Internal/Trees/RedBlackTree.cs
@@ -31,7 +31,7 @@ namespace NMemory.DataStructures.Internal.Trees
 
     //// Red-black tree structure based on:
     //// http://www.jot.fm/issues/issue_2005_03/column6/
-    internal class RedBlackTree<TKey, TValue> : IDictionary<TKey, TValue>
+	public class RedBlackTree<TKey, TValue> : IDictionary<TKey, TValue>
     {
         private IComparer<TKey> comparer;
 
@@ -99,7 +99,7 @@ namespace NMemory.DataStructures.Internal.Trees
             }
         }
 
-        internal RedBlackTreeNode<TKey, TValue> RootElement
+		public RedBlackTreeNode<TKey, TValue> RootElement
         {
             get { return this.root; }
         }

--- a/Main/Source/NMemory/DataStructures/Internal/Trees/RedBlackTreeNode.cs
+++ b/Main/Source/NMemory/DataStructures/Internal/Trees/RedBlackTreeNode.cs
@@ -29,7 +29,7 @@ namespace NMemory.DataStructures.Internal.Trees
     using System.Linq;
     using System.Text;
 
-    internal class RedBlackTreeNode<TKey, TValue>
+	public class RedBlackTreeNode<TKey, TValue>
     {
         private WeakReference parent; 
 

--- a/Main/Source/NMemory/Database.cs
+++ b/Main/Source/NMemory/Database.cs
@@ -22,6 +22,8 @@
 // </copyright>
 // ----------------------------------------------------------------------------------
 
+using NMemory.Indexes;
+
 namespace NMemory
 {
     using System;
@@ -37,6 +39,10 @@ namespace NMemory
         private IDatabaseEngine databaseEngine;
         private StoredProcedureCollection storedProcedures;
         private TableCollection tables;
+
+	    static Database() { //need to register this Delegate to separate Implementation from Interface
+		    ModularKeyInfoFactory.Register();
+	    }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Database" /> class.

--- a/Main/Source/NMemory/Exceptions/ExceptionMessages.cs
+++ b/Main/Source/NMemory/Exceptions/ExceptionMessages.cs
@@ -24,7 +24,7 @@
 
 namespace NMemory.Exceptions
 {
-    internal static class ExceptionMessages
+    public static class ExceptionMessages
     {
         public static readonly string Missing = string.Empty;
 

--- a/Main/Source/NMemory/Execution/ExecutionContext.cs
+++ b/Main/Source/NMemory/Execution/ExecutionContext.cs
@@ -29,7 +29,7 @@ namespace NMemory.Execution
     using NMemory.Modularity;
     using NMemory.Transactions;
 
-    internal class ExecutionContext : IExecutionContext
+	public class ExecutionContext : IExecutionContext
     {
         private Transaction transaction;
         private IDictionary<string, object> parameters;

--- a/Main/Source/NMemory/Execution/Optimization/JoinGroup.cs
+++ b/Main/Source/NMemory/Execution/Optimization/JoinGroup.cs
@@ -30,7 +30,7 @@ namespace NMemory.Execution.Optimization
     /// Provides factory method for <see cref="GroupJoin{TOuter, TInner}"/> in order to
     /// achieve type impeance.
     /// </summary>
-    internal static class JoinGroup
+	public static class JoinGroup
     {
         public static JoinGroup<TOuter, TInner> Create<TOuter, TInner>(
             TOuter outer,

--- a/Main/Source/NMemory/Execution/Optimization/JoinGroup`2.cs
+++ b/Main/Source/NMemory/Execution/Optimization/JoinGroup`2.cs
@@ -26,7 +26,7 @@ namespace NMemory.Execution.Optimization
 {
     using System.Collections.Generic;
 
-    internal class JoinGroup<TOuter, TInner>
+	public class JoinGroup<TOuter, TInner>
     {
         private TOuter outer;
         private IEnumerable<TInner> inner;

--- a/Main/Source/NMemory/Execution/Primitives/IDeletePrimitive.cs
+++ b/Main/Source/NMemory/Execution/Primitives/IDeletePrimitive.cs
@@ -28,7 +28,7 @@ namespace NMemory.Execution.Primitives
     using NMemory.Tables;
     using NMemory.Transactions.Logs;
 
-    internal interface IDeletePrimitive
+    public interface IDeletePrimitive
     {
         void Delete<T>(IList<T> storedEntities) where T : class;
     }

--- a/Main/Source/NMemory/Indexes/IKeyInfoFactory.cs
+++ b/Main/Source/NMemory/Indexes/IKeyInfoFactory.cs
@@ -22,10 +22,16 @@
 // </copyright>
 // ----------------------------------------------------------------------------------
 
+using NMemory.Modularity;
+
 namespace NMemory.Indexes
 {
     using System;
     using System.Linq.Expressions;
+
+	public static class KeyInfoFactory {
+		public static Func<IDatabase, IKeyInfoFactory> ModularKeyInfoFactory;
+	}
 
     public interface IKeyInfoFactory
     {

--- a/Main/Source/NMemory/Indexes/Index.cs
+++ b/Main/Source/NMemory/Indexes/Index.cs
@@ -35,7 +35,7 @@ namespace NMemory.Indexes
 
         #region Ctor
 
-        internal Index(
+		public Index(
             ITable<TEntity> table, 
             IKeyInfo<TEntity, TKey> keyInfo, 
             IDataStructure<TKey, TEntity> dataStructure)

--- a/Main/Source/NMemory/Indexes/ModularKeyInfoFactory.cs
+++ b/Main/Source/NMemory/Indexes/ModularKeyInfoFactory.cs
@@ -33,6 +33,11 @@ namespace NMemory.Indexes
 
     public class ModularKeyInfoFactory : IKeyInfoFactory
     {
+		/// <summary> need to register this Delegate to separate Implementation from Interface </summary>
+	    public static void Register() {
+			KeyInfoFactory.ModularKeyInfoFactory = database => new ModularKeyInfoFactory(database);
+	    }
+
         private readonly IKeyInfoService service;
 
         protected ModularKeyInfoFactory(IKeyInfoService service)

--- a/Main/Source/NMemory/Indexes/UniqueIndex.cs
+++ b/Main/Source/NMemory/Indexes/UniqueIndex.cs
@@ -36,7 +36,7 @@ namespace NMemory.Indexes
 
         #region Ctor
 
-        internal UniqueIndex(
+		public UniqueIndex(
             ITable<TEntity> table, 
             IKeyInfo<TEntity, TUniqueKey> keyInfo, 
             IUniqueDataStructure<TUniqueKey, TEntity> dataStructure)

--- a/Main/Source/NMemory/Linq/QueryableEx.cs
+++ b/Main/Source/NMemory/Linq/QueryableEx.cs
@@ -122,7 +122,7 @@ namespace NMemory.Linq
             return Execute<T>(queryable, parameters, Transaction.TryGetAmbientEnlistedTransaction());
         }
 
-        internal static IEnumerable<T> Execute<T>(this IQueryable<T> queryable, IDictionary<string, object> parameters, Transaction transaction)
+        public static IEnumerable<T> Execute<T>(this IQueryable<T> queryable, IDictionary<string, object> parameters, Transaction transaction)
         {
             if (queryable == null)
             {

--- a/Main/Source/NMemory/Linq/TableQuery`1.cs
+++ b/Main/Source/NMemory/Linq/TableQuery`1.cs
@@ -40,7 +40,7 @@ namespace NMemory.Linq
 
         #region Ctor
 
-        internal TableQuery(IDatabase database, Expression expression, IQueryProvider provider) 
+        public TableQuery(IDatabase database, Expression expression, IQueryProvider provider) 
             : base(database, expression, provider)
         {
             this.storeCompilation = false;
@@ -87,7 +87,7 @@ namespace NMemory.Linq
             return GetEnumerator(null, Transaction.TryGetAmbientEnlistedTransaction());
         }
 
-        internal IEnumerator<TEntity> GetEnumerator(
+        public IEnumerator<TEntity> GetEnumerator(
             IDictionary<string, object> parameters, 
             Transaction transaction)
         {

--- a/Main/Source/NMemory/NMemory.Interface.csproj
+++ b/Main/Source/NMemory/NMemory.Interface.csproj
@@ -1,0 +1,203 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{0AE29C99-7824-4F13-BC92-B2C71AB60CEA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NMemory</RootNamespace>
+    <AssemblyName>NMemory.Interface</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DocumentationFile>bin\Release\NMemory.Interface.xml</DocumentationFile>
+  </PropertyGroup>
+  <Import Project="..\AssemblySigning.targets" />
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Common\DefaultEntityMemberInfoServices`2.cs" />
+    <Compile Include="Common\DefaultEntityMemberInfo`2.cs" />
+    <Compile Include="Common\DynamicMethodBuilder.cs" />
+    <Compile Include="Common\ExpressionHelper.cs" />
+    <Compile Include="Common\IEntityMemberInfo.cs" />
+    <Compile Include="Common\IEntityMemberInfoServicesProvider`2.cs" />
+    <Compile Include="Common\IEntityMemberInfoServices`2.cs" />
+    <Compile Include="Common\IEntityMemberInfo`1.cs" />
+    <Compile Include="Common\IEntityMemberInfo`2.cs" />
+    <Compile Include="Common\KeyExpressionHelper.cs" />
+    <Compile Include="Common\ReflectionHelper.cs" />
+    <Compile Include="Common\TupleTypeHelper.cs" />
+    <Compile Include="Common\Visitors\ParameterChangeVisitor.cs" />
+    <Compile Include="Common\Visitors\StoredProcedureParameterSearchVisitor.cs" />
+    <Compile Include="Concurrency\Locks\ILock.cs" />
+    <Compile Include="Concurrency\Locks\ILockFactory.cs" />
+    <Compile Include="Concurrency\Locks\LightweightSpinLock.cs" />
+    <Compile Include="Constraints\ConstraintBase.cs" />
+    <Compile Include="Constraints\IConstraint.cs" />
+    <Compile Include="Constraints\IConstraintFactory`1.cs" />
+    <Compile Include="Constraints\IConstraint`1.cs" />
+    <Compile Include="Constraints\TimestampConstraint.cs" />
+    <Compile Include="DataStructures\Hashtable.cs" />
+    <Compile Include="DataStructures\IDataStructure.cs" />
+    <Compile Include="DataStructures\IIntervalSearchable.cs" />
+    <Compile Include="DataStructures\IUniqueDataStructure.cs" />
+    <Compile Include="DataStructures\UniqueHashtable.cs" />
+    <Compile Include="Data\Binary.cs" />
+    <Compile Include="Data\Timestamp.cs" />
+    <Compile Include="Diagnostics\Messages\Message.cs" />
+    <Compile Include="Exceptions\ErrorCode.cs" />
+    <Compile Include="Exceptions\ExceptionMessages.cs" />
+    <Compile Include="Exceptions\ForeignKeyViolationException.cs" />
+    <Compile Include="Exceptions\MultipleUniqueKeyFoundException.cs" />
+    <Compile Include="Exceptions\NMemoryException.cs" />
+    <Compile Include="Exceptions\ParameterException.cs" />
+    <Compile Include="Execution\EntityUpdater`1.cs" />
+    <Compile Include="Execution\ExecutionContext.cs" />
+    <Compile Include="Execution\ExpressionUpdater`1.cs" />
+    <Compile Include="Execution\IExecutionContext.cs" />
+    <Compile Include="Execution\IExecutionPlan.cs" />
+    <Compile Include="Execution\IExecutionPlanInfo.cs" />
+    <Compile Include="Execution\IExecutionPlan`1.cs" />
+    <Compile Include="Execution\IUpdater`1.cs" />
+    <Compile Include="Execution\OperationType.cs" />
+    <Compile Include="Execution\Optimization\IExpressionRewriter.cs" />
+    <Compile Include="Execution\Optimization\ITransformationContext.cs" />
+    <Compile Include="Execution\Optimization\ITransformationStep.cs" />
+    <Compile Include="Execution\Primitives\IDeletePrimitive.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Indexes\DictionaryIndexFactory.cs" />
+    <Compile Include="Indexes\IIndex.cs" />
+    <Compile Include="Indexes\IIndexFactory.cs" />
+    <Compile Include="Indexes\IIndex`1.cs" />
+    <Compile Include="Indexes\IIndex`2.cs" />
+    <Compile Include="Indexes\IKeyInfo.cs" />
+    <Compile Include="Indexes\IKeyInfoFactory.cs" />
+    <Compile Include="Indexes\IKeyInfoHelper.cs" />
+    <Compile Include="Indexes\IKeyInfoHelperProvider.cs" />
+    <Compile Include="Indexes\IKeyInfo`1.cs" />
+    <Compile Include="Indexes\IKeyInfo`2.cs" />
+    <Compile Include="Indexes\Index.cs" />
+    <Compile Include="Indexes\IndexBase.cs" />
+    <Compile Include="Indexes\IndexFactoryBase.cs" />
+    <Compile Include="Indexes\IUniqueIndex.cs" />
+    <Compile Include="Indexes\IUniqueIndex`1.cs" />
+    <Compile Include="Indexes\IUniqueIndex`2.cs" />
+    <Compile Include="Indexes\SortOrder.cs" />
+    <Compile Include="Indexes\TupleKeyInfoHelper.cs" />
+    <Compile Include="Indexes\UniqueIndex.cs" />
+    <Compile Include="Linq\IIndexedQueryable.cs" />
+    <Compile Include="Linq\IndexedQueryable.cs" />
+    <Compile Include="Linq\ITableQuery.cs" />
+    <Compile Include="Linq\QueryableEx.cs" />
+    <Compile Include="Linq\TableQuery.cs" />
+    <Compile Include="Linq\TableQueryProvider.cs" />
+    <Compile Include="Linq\TableQueryWrapper`1.cs" />
+    <Compile Include="Linq\TableQuery`1.cs" />
+    <Compile Include="Modularity\DefaultDatabaseEngine.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Modularity\IConcurrencyManager.cs" />
+    <Compile Include="Modularity\IServiceProvider.cs" />
+    <Compile Include="Modularity\IDatabase.cs" />
+    <Compile Include="Modularity\ILoggingPort.cs" />
+    <Compile Include="Modularity\ITransactionHandler.cs" />
+    <Compile Include="Properties\AssemblyVersion.cs" />
+    <Compile Include="Properties\AssemblyVisibility.cs" />
+    <Compile Include="Modularity\IDatabaseEngine.cs" />
+    <Compile Include="Modularity\IDatabaseComponent.cs" />
+    <Compile Include="Modularity\IDatabaseComponentFactory.cs" />
+    <Compile Include="Modularity\ITableCatalog.cs" />
+    <Compile Include="Modularity\IExtensible.cs" />
+    <Compile Include="Modularity\IQueryCompiler.cs" />
+    <Compile Include="Modularity\ICommandExecutor.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\Contracts\IEntityService.cs" />
+    <Compile Include="Services\Contracts\IKeyInfoService.cs" />
+    <Compile Include="Services\Contracts\ITableService.cs" />
+    <Compile Include="StoredProcedures\IParameter.cs" />
+    <Compile Include="StoredProcedures\ISharedStoredProcedure.cs" />
+    <Compile Include="StoredProcedures\ISharedStoredProcedure`1.cs" />
+    <Compile Include="StoredProcedures\IStoredProcedure.cs" />
+    <Compile Include="StoredProcedures\IStoredProcedure`1.cs" />
+    <Compile Include="StoredProcedures\ParameterDescription.cs" />
+    <Compile Include="StoredProcedures\StoredProcedureBase.cs" />
+    <Compile Include="StoredProcedures\StoredProcedureCollection.cs" />
+    <Compile Include="StoredProcedures\StoredProcedure`1.cs" />
+    <Compile Include="Tables\ConstraintCollection`1.cs" />
+    <Compile Include="Tables\IBulkTable.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\IdentityField.cs" />
+    <Compile Include="Tables\IdentitySpecification.cs" />
+    <Compile Include="Tables\IReflectionTable.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\IRelation.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\IRelationContraint.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\IRelationInternal.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\ITable.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\ITable`1.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\ITable`2.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Tables\Relation.cs" />
+    <Compile Include="Tables\RelationConstraint.cs" />
+    <Compile Include="Tables\RelationConstraint`3.cs" />
+    <Compile Include="Tables\RelationGroup.cs" />
+    <Compile Include="Tables\RelationKeyConverterFactory.cs" />
+    <Compile Include="Tables\RelationOptions.cs" />
+    <Compile Include="Tables\TableCollection.cs" />
+    <Compile Include="Tables\Table`2.cs" />
+    <Compile Include="Transactions\AmbientTransactionStore.cs" />
+    <Compile Include="Transactions\IsolationLevels.cs" />
+    <Compile Include="Transactions\Logs\ITransactionLog.cs" />
+    <Compile Include="Transactions\Logs\ITransactionLogItem.cs" />
+    <Compile Include="Transactions\Transaction.cs" />
+    <Compile Include="Transactions\TransactionContext.cs" />
+    <Compile Include="Utilities\TableCollectionExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Main/Source/NMemory/NMemory.Interface.csproj
+++ b/Main/Source/NMemory/NMemory.Interface.csproj
@@ -126,8 +126,8 @@
     <Compile Include="Modularity\IDatabase.cs" />
     <Compile Include="Modularity\ILoggingPort.cs" />
     <Compile Include="Modularity\ITransactionHandler.cs" />
+    <Compile Include="Properties\AssemblyInfo.Interface.cs" />
     <Compile Include="Properties\AssemblyVersion.cs" />
-    <Compile Include="Properties\AssemblyVisibility.cs" />
     <Compile Include="Modularity\IDatabaseEngine.cs" />
     <Compile Include="Modularity\IDatabaseComponent.cs" />
     <Compile Include="Modularity\IDatabaseComponentFactory.cs" />
@@ -135,7 +135,6 @@
     <Compile Include="Modularity\IExtensible.cs" />
     <Compile Include="Modularity\IQueryCompiler.cs" />
     <Compile Include="Modularity\ICommandExecutor.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Contracts\IEntityService.cs" />
     <Compile Include="Services\Contracts\IKeyInfoService.cs" />
     <Compile Include="Services\Contracts\ITableService.cs" />

--- a/Main/Source/NMemory/NMemory.csproj
+++ b/Main/Source/NMemory/NMemory.csproj
@@ -40,51 +40,27 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\CollectionExtensions.cs" />
-    <Compile Include="Common\DefaultEntityMemberInfo`2.cs" />
-    <Compile Include="Common\DefaultEntityMemberInfoServices`2.cs" />
     <Compile Include="Common\Expressions\IExpressionBuilder.cs" />
     <Compile Include="Common\Expressions\UnaryExpressionCloner.cs" />
-    <Compile Include="Common\IEntityMemberInfoServicesProvider`2.cs" />
-    <Compile Include="Common\IEntityMemberInfoServices`2.cs" />
-    <Compile Include="Common\IEntityMemberInfo`2.cs" />
     <Compile Include="Common\DatabaseMembers.cs" />
     <Compile Include="Common\DatabaseReflectionHelper.cs" />
-    <Compile Include="Common\ExpressionHelper.cs" />
-    <Compile Include="Common\IEntityMemberInfo.cs" />
-    <Compile Include="Common\IEntityMemberInfo`1.cs" />
-    <Compile Include="Common\KeyExpressionHelper.cs" />
+
     <Compile Include="Common\LinqJoinKeyHelper.cs" />
     <Compile Include="Common\MemberChain.cs" />
     <Compile Include="Common\QueryExpressionHelper.cs" />
     <Compile Include="Common\TableLocator.cs" />
-    <Compile Include="Common\TupleTypeHelper.cs" />
     <Compile Include="Common\Visitors\EntityTypeSearchVisitor.cs" />
     <Compile Include="Common\Visitors\ExpressionSearchVisitor.cs" />
-    <Compile Include="Constraints\IConstraint.cs" />
     <Compile Include="Constraints\GeneratedGuidConstraint.cs" />
-    <Compile Include="Constraints\IConstraintFactory`1.cs" />
     <Compile Include="Constraints\NotNullableConstraint.cs" />
     <Compile Include="Diagnostics\Messages\JoinArgumentsOrderSwappedMessage.cs" />
     <Compile Include="Diagnostics\Messages\JoinOperatorsSwappedMessage.cs" />
-    <Compile Include="Exceptions\ExceptionMessages.cs" />
     <Compile Include="Execution\ExecutionContextExtensions.cs" />
     <Compile Include="Execution\ExecutionHelper.cs" />
     <Compile Include="Execution\Primitives\DeletePrimitive.cs" />
-    <Compile Include="Execution\Primitives\IDeletePrimitive.cs" />
-    <Compile Include="Execution\EntityUpdater`1.cs" />
-    <Compile Include="Execution\ExpressionUpdater`1.cs" />
     <Compile Include="Execution\ExecutionPlan.cs" />
     <Compile Include="Execution\ExecutionPlanInfo.cs" />
-    <Compile Include="Execution\IExecutionPlan.cs" />
-    <Compile Include="Execution\IExecutionPlanInfo.cs" />
-    <Compile Include="Execution\IExecutionPlan`1.cs" />
-    <Compile Include="Execution\IUpdater`1.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Execution\OperationType.cs" />
     <Compile Include="Execution\Optimization\EqualityMappingDetector.cs" />
-    <Compile Include="Execution\Optimization\ITransformationContext.cs" />
-    <Compile Include="Execution\Optimization\ITransformationStep.cs" />
     <Compile Include="Execution\Optimization\JoinGroup.cs" />
     <Compile Include="Execution\Optimization\JoinGroup`2.cs" />
     <Compile Include="Execution\Optimization\Rewriters\GroupJoinPhysicalRewriter.cs" />
@@ -103,81 +79,48 @@
     <Compile Include="Execution\Optimization\TransformationStepRecorder.cs" />
     <Compile Include="Indexes\AnonymousTypeKeyInfoHelper.cs" />
     <Compile Include="Indexes\DefaultKeyInfoFactory.cs" />
-    <Compile Include="Indexes\IKeyInfoFactory.cs" />
-    <Compile Include="Indexes\IKeyInfo`1.cs" />
     <Compile Include="Indexes\GenericKeyComparer`1.cs" />
     <Compile Include="Indexes\ModularKeyInfoFactory.cs" />
     <Compile Include="Indexes\PrimitiveKeyInfoHelper.cs" />
     <Compile Include="Indexes\PrimitiveComparer.cs" />
     <Compile Include="Indexes\PrimitiveKeyComparer`1.cs" />
     <Compile Include="Common\QueryMethods.cs" />
-    <Compile Include="Common\ReflectionHelper.cs" />
-    <Compile Include="Common\Visitors\ParameterChangeVisitor.cs" />
+
     <Compile Include="Common\Visitors\ReplaceVisitor.cs" />
-    <Compile Include="Common\Visitors\StoredProcedureParameterSearchVisitor.cs" />
     <Compile Include="Concurrency\ChaosConcurrencyManager.cs" />
     <Compile Include="Concurrency\TableLockConcurrencyManager.cs" />
     <Compile Include="Concurrency\EntrantCounter.cs" />
-    <Compile Include="Concurrency\Locks\LightweightSpinLock.cs" />
     <Compile Include="Concurrency\Locks\UncheckedReaderWriterLock.cs" />
     <Compile Include="Concurrency\Locks\WaitingToken.cs" />
     <Compile Include="Concurrency\TransactionLockInventory.cs" />
-    <Compile Include="Constraints\ConstraintBase.cs" />
-    <Compile Include="Constraints\IConstraint`1.cs" />
     <Compile Include="Constraints\NCharConstraint.cs" />
     <Compile Include="Constraints\NumericConstraint.cs" />
     <Compile Include="Constraints\NVarCharConstraint.cs" />
-    <Compile Include="Constraints\TimestampConstraint.cs" />
     <Compile Include="Database.cs" />
-    <Compile Include="DataStructures\Hashtable.cs" />
-    <Compile Include="DataStructures\IDataStructure.cs" />
-    <Compile Include="DataStructures\IIntervalSearchable.cs" />
     <Compile Include="DataStructures\Internal\Graphs\Graph.cs" />
     <Compile Include="DataStructures\Internal\Trees\RedBlackTree.cs" />
     <Compile Include="DataStructures\Internal\Trees\RedBlackTreeNode.cs" />
-    <Compile Include="DataStructures\IUniqueDataStructure.cs" />
     <Compile Include="DataStructures\RedBlackTree.cs" />
-    <Compile Include="DataStructures\UniqueHashtable.cs" />
     <Compile Include="DataStructures\UniqueRedBlackTree.cs" />
-    <Compile Include="Data\Binary.cs" />
-    <Compile Include="Data\Timestamp.cs" />
     <Compile Include="Diagnostics\ConsoleLoggingPort.cs" />
     <Compile Include="Indexes\AnonymousTypeKeyInfo.cs" />
     <Compile Include="Indexes\AnonymousTypeKeyInfo`2.cs" />
-    <Compile Include="Indexes\IKeyInfoHelper.cs" />
-    <Compile Include="Indexes\IKeyInfoHelperProvider.cs" />
-    <Compile Include="Indexes\IUniqueIndex.cs" />
-    <Compile Include="Indexes\IUniqueIndex`1.cs" />
     <Compile Include="Indexes\KeyInfoBase.cs" />
     <Compile Include="Indexes\PrimitiveKeyInfo.cs" />
     <Compile Include="Indexes\PrimitiveKeyInfo`2.cs" />
-    <Compile Include="Indexes\SortOrder.cs" />
     <Compile Include="Indexes\TupleKeyInfo.cs" />
-    <Compile Include="Indexes\TupleKeyInfoHelper.cs" />
     <Compile Include="Indexes\TupleKeyInfo`2.cs" />
     <Compile Include="Linq\EnumerableEx.cs" />
-    <Compile Include="Linq\TableQueryWrapper`1.cs" />
-    <Compile Include="Modularity\IServiceProvider.cs" />
     <Compile Include="Modularity\DefaultDatabaseEngine.cs" />
-    <Compile Include="Modularity\IDatabase.cs" />
-    <Compile Include="Modularity\ILoggingPort.cs" />
     <Compile Include="Diagnostics\MessageBuffer.cs" />
     <Compile Include="Diagnostics\Messages\IndexFoundMessage.cs" />
-    <Compile Include="Diagnostics\Messages\Message.cs" />
     <Compile Include="Diagnostics\Messages\PreferredIndexMessage.cs" />
     <Compile Include="Diagnostics\Messages\StandardMessage.cs" />
     <Compile Include="Diagnostics\Messages\TableMessage.cs" />
     <Compile Include="Exceptions\ConstraintException.cs" />
     <Compile Include="Exceptions\DeadlockException.cs" />
-    <Compile Include="Exceptions\ErrorCode.cs" />
-    <Compile Include="Exceptions\ForeignKeyViolationException.cs" />
     <Compile Include="Exceptions\IndexKeyTypeNotSupportedException.cs" />
-    <Compile Include="Exceptions\NMemoryException.cs" />
-    <Compile Include="Exceptions\MultipleUniqueKeyFoundException.cs" />
-    <Compile Include="Exceptions\ParameterException.cs" />
-    <Compile Include="Execution\ExecutionContext.cs" />
-    <Compile Include="Execution\IExecutionContext.cs" />
-    <Compile Include="Execution\Optimization\IExpressionRewriter.cs" />
+
     <Compile Include="Execution\Optimization\Rewriters\ExpressionRewriterBase.cs" />
     <Compile Include="Execution\Optimization\Rewriters\StoredProcedureParameterRewriter.cs" />
     <Compile Include="Execution\Optimization\Rewriters\TableScanRewriter.cs" />
@@ -185,33 +128,13 @@
     <Compile Include="Execution\QueryCompilerBase.cs" />
     <Compile Include="Execution\CommandExecutor.cs" />
     <Compile Include="Functions.cs" />
-    <Compile Include="Indexes\DictionaryIndexFactory.cs" />
-    <Compile Include="Indexes\IIndex.cs" />
-    <Compile Include="Indexes\IIndex`1.cs" />
-    <Compile Include="Indexes\IKeyInfo.cs" />
-    <Compile Include="Indexes\IKeyInfo`2.cs" />
-    <Compile Include="Indexes\Index.cs" />
-    <Compile Include="Indexes\IndexBase.cs" />
-    <Compile Include="Indexes\IIndexFactory.cs" />
-    <Compile Include="Indexes\IIndex`2.cs" />
-    <Compile Include="Indexes\IndexFactoryBase.cs" />
-    <Compile Include="Indexes\IUniqueIndex`2.cs" />
+
     <Compile Include="Indexes\RedBlackTreeIndexFactory.cs" />
-    <Compile Include="Indexes\UniqueIndex.cs" />
-    <Compile Include="Linq\IIndexedQueryable.cs" />
-    <Compile Include="Linq\IndexedQueryable.cs" />
-    <Compile Include="Linq\ITableQuery.cs" />
-    <Compile Include="Linq\TableQuery.cs" />
-    <Compile Include="Linq\TableQuery`1.cs" />
-    <Compile Include="Linq\TableQueryProvider.cs" />
-    <Compile Include="Linq\QueryableEx.cs" />
-    <Compile Include="Common\DynamicMethodBuilder.cs" />
+
+
     <Compile Include="Modularity\DefaultDatabaseComponentFactory.cs" />
-    <Compile Include="Properties\AssemblyVersion.cs" />
-    <Compile Include="Properties\AssemblyVisibility.cs" />
-    <Compile Include="Services\Contracts\IEntityService.cs" />
+
     <Compile Include="Services\DefaultServiceConfigurations.cs" />
-    <Compile Include="Services\Contracts\ITableService.cs" />
     <Compile Include="Services\AnonymousTypeKeyInfoService.cs" />
     <Compile Include="Services\DefaultServiceProvider.cs" />
     <Compile Include="Services\DefaultEntityService.cs" />
@@ -219,74 +142,34 @@
     <Compile Include="Services\TupleKeyInfoService.cs" />
     <Compile Include="Services\CombinedKeyInfoService.cs" />
     <Compile Include="Services\ServiceProviderBase.cs" />
-    <Compile Include="Services\Contracts\IKeyInfoService.cs" />
-    <Compile Include="StoredProcedures\StoredProcedureBase.cs" />
     <Compile Include="Services\DefaultTableService.cs" />
-    <Compile Include="Modularity\IConcurrencyManager.cs" />
-    <Compile Include="Modularity\IDatabaseEngine.cs" />
-    <Compile Include="Modularity\IDatabaseComponent.cs" />
-    <Compile Include="Modularity\IDatabaseComponentFactory.cs" />
-    <Compile Include="Modularity\ITableCatalog.cs" />
-    <Compile Include="Modularity\IExtensible.cs" />
-    <Compile Include="Modularity\IQueryCompiler.cs" />
-    <Compile Include="Modularity\ICommandExecutor.cs" />
-    <Compile Include="Modularity\ITransactionHandler.cs" />
-    <Compile Include="StoredProcedures\ISharedStoredProcedure`1.cs" />
-    <Compile Include="StoredProcedures\IParameter.cs" />
-    <Compile Include="StoredProcedures\ISharedStoredProcedure.cs" />
-    <Compile Include="StoredProcedures\IStoredProcedure.cs" />
-    <Compile Include="StoredProcedures\IStoredProcedure`1.cs" />
-    <Compile Include="StoredProcedures\ParameterDescription.cs" />
     <Compile Include="StoredProcedures\Parameter.cs" />
     <Compile Include="StoredProcedures\SharedStoredProcedure`2.cs" />
-    <Compile Include="StoredProcedures\StoredProcedure`1.cs" />
     <Compile Include="Concurrency\DeadlockManagementStrategy.cs" />
-    <Compile Include="Concurrency\Locks\ILock.cs" />
-    <Compile Include="Concurrency\Locks\ILockFactory.cs" />
     <Compile Include="Concurrency\Locks\DefaultLockFactory.cs" />
     <Compile Include="Execution\QueryCompiler.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Tables\ConstraintCollection`1.cs" />
     <Compile Include="Tables\DefaultTable.cs" />
-    <Compile Include="Tables\IBulkTable.cs" />
-    <Compile Include="Tables\IRelationInternal.cs" />
-    <Compile Include="Tables\IRelation.cs" />
-    <Compile Include="Tables\IRelationContraint.cs" />
-    <Compile Include="Tables\Relation.cs" />
-    <Compile Include="StoredProcedures\StoredProcedureCollection.cs" />
     <Compile Include="Tables\EntityPropertyChangeDetector.cs" />
     <Compile Include="Tables\EntityPropertyCloner.cs" />
-    <Compile Include="Tables\IdentityField.cs" />
-    <Compile Include="Tables\IdentitySpecification.cs" />
-    <Compile Include="Tables\IReflectionTable.cs" />
-    <Compile Include="Tables\ITable.cs" />
-    <Compile Include="Tables\ITable`1.cs" />
-    <Compile Include="Tables\ITable`2.cs" />
-    <Compile Include="Tables\RelationConstraint.cs" />
-    <Compile Include="Tables\RelationConstraint`3.cs" />
-    <Compile Include="Tables\RelationKeyConverterFactory.cs" />
-    <Compile Include="Tables\RelationGroup.cs" />
-    <Compile Include="Tables\RelationOptions.cs" />
-    <Compile Include="Tables\Table`2.cs" />
-    <Compile Include="Tables\TableCollection.cs" />
+
+
     <Compile Include="Transactions\Logs\AtomicLogScope.cs" />
     <Compile Include="Transactions\Logs\IndexDeleteTransactionLogItem`1.cs" />
     <Compile Include="Transactions\Logs\IndexInsertTransactionLogItem`1.cs" />
-    <Compile Include="Transactions\Logs\ITransactionLog.cs" />
-    <Compile Include="Transactions\Logs\ITransactionLogItem.cs" />
-    <Compile Include="Transactions\IsolationLevels.cs" />
     <Compile Include="Transactions\Logs\TransactionLog.cs" />
     <Compile Include="Transactions\Logs\IndexTransactionLogItemBase`1.cs" />
     <Compile Include="Transactions\Logs\TransactionLogExtensions.cs" />
     <Compile Include="Transactions\Logs\UpdateEntityLogItem`1.cs" />
-    <Compile Include="Transactions\Transaction.cs" />
     <Compile Include="Transactions\TransactionHandler.cs" />
-    <Compile Include="Transactions\TransactionContext.cs" />
-    <Compile Include="Transactions\AmbientTransactionStore.cs" />
-    <Compile Include="Utilities\TableCollectionExtensions.cs" />
+
     <Compile Include="Utilities\TableExtensions.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="NMemory.Interface.csproj">
+      <Project>{0ae29c99-7824-4f13-bc92-b2c71ab60cea}</Project>
+      <Name>NMemory.Interface</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Main/Source/NMemory/NMemory.csproj
+++ b/Main/Source/NMemory/NMemory.csproj
@@ -44,7 +44,6 @@
     <Compile Include="Common\Expressions\UnaryExpressionCloner.cs" />
     <Compile Include="Common\DatabaseMembers.cs" />
     <Compile Include="Common\DatabaseReflectionHelper.cs" />
-
     <Compile Include="Common\LinqJoinKeyHelper.cs" />
     <Compile Include="Common\MemberChain.cs" />
     <Compile Include="Common\QueryExpressionHelper.cs" />
@@ -85,7 +84,6 @@
     <Compile Include="Indexes\PrimitiveComparer.cs" />
     <Compile Include="Indexes\PrimitiveKeyComparer`1.cs" />
     <Compile Include="Common\QueryMethods.cs" />
-
     <Compile Include="Common\Visitors\ReplaceVisitor.cs" />
     <Compile Include="Concurrency\ChaosConcurrencyManager.cs" />
     <Compile Include="Concurrency\TableLockConcurrencyManager.cs" />
@@ -120,7 +118,6 @@
     <Compile Include="Exceptions\ConstraintException.cs" />
     <Compile Include="Exceptions\DeadlockException.cs" />
     <Compile Include="Exceptions\IndexKeyTypeNotSupportedException.cs" />
-
     <Compile Include="Execution\Optimization\Rewriters\ExpressionRewriterBase.cs" />
     <Compile Include="Execution\Optimization\Rewriters\StoredProcedureParameterRewriter.cs" />
     <Compile Include="Execution\Optimization\Rewriters\TableScanRewriter.cs" />
@@ -128,12 +125,10 @@
     <Compile Include="Execution\QueryCompilerBase.cs" />
     <Compile Include="Execution\CommandExecutor.cs" />
     <Compile Include="Functions.cs" />
-
     <Compile Include="Indexes\RedBlackTreeIndexFactory.cs" />
-
-
     <Compile Include="Modularity\DefaultDatabaseComponentFactory.cs" />
-
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyVersion.cs" />
     <Compile Include="Services\DefaultServiceConfigurations.cs" />
     <Compile Include="Services\AnonymousTypeKeyInfoService.cs" />
     <Compile Include="Services\DefaultServiceProvider.cs" />
@@ -151,8 +146,6 @@
     <Compile Include="Tables\DefaultTable.cs" />
     <Compile Include="Tables\EntityPropertyChangeDetector.cs" />
     <Compile Include="Tables\EntityPropertyCloner.cs" />
-
-
     <Compile Include="Transactions\Logs\AtomicLogScope.cs" />
     <Compile Include="Transactions\Logs\IndexDeleteTransactionLogItem`1.cs" />
     <Compile Include="Transactions\Logs\IndexInsertTransactionLogItem`1.cs" />
@@ -161,7 +154,6 @@
     <Compile Include="Transactions\Logs\TransactionLogExtensions.cs" />
     <Compile Include="Transactions\Logs\UpdateEntityLogItem`1.cs" />
     <Compile Include="Transactions\TransactionHandler.cs" />
-
     <Compile Include="Utilities\TableExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Main/Source/NMemory/Properties/AssemblyInfo.Interface.cs
+++ b/Main/Source/NMemory/Properties/AssemblyInfo.Interface.cs
@@ -1,0 +1,47 @@
+﻿// ----------------------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="NMemory Team">
+//     Copyright (C) NMemory Team
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in
+//     all copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//     THE SOFTWARE.
+// </copyright>
+// ----------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NMemory.Interface")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NMemory")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5503d327-916a-494b-8bda-83b85da942a9")]

--- a/Main/Source/NMemory/Properties/AssemblyVersion.cs
+++ b/Main/Source/NMemory/Properties/AssemblyVersion.cs
@@ -1,28 +1,4 @@
-﻿// ----------------------------------------------------------------------------------
-// <copyright file="AssemblyVersion.cs" company="NMemory Team">
-//     Copyright (C) NMemory Team
-//
-//     Permission is hereby granted, free of charge, to any person obtaining a copy
-//     of this software and associated documentation files (the "Software"), to deal
-//     in the Software without restriction, including without limitation the rights
-//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//     copies of the Software, and to permit persons to whom the Software is
-//     furnished to do so, subject to the following conditions:
-//
-//     The above copyright notice and this permission notice shall be included in
-//     all copies or substantial portions of the Software.
-//
-//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-//     THE SOFTWARE.
-// </copyright>
-// ----------------------------------------------------------------------------------
-
-using System.Reflection;
+﻿using System.Reflection;
 
 // Version information for an assembly consists of the following four values:
 //

--- a/Main/Source/NMemory/StoredProcedures/StoredProcedureCollection.cs
+++ b/Main/Source/NMemory/StoredProcedures/StoredProcedureCollection.cs
@@ -22,6 +22,8 @@
 // </copyright>
 // ----------------------------------------------------------------------------------
 
+using NMemory.Modularity;
+
 namespace NMemory.StoredProcedures
 {
     using System;
@@ -34,7 +36,7 @@ namespace NMemory.StoredProcedures
         private WeakReference database;
         private List<object> storedProcedures;
 
-        internal StoredProcedureCollection(Database database)
+        public StoredProcedureCollection(IDatabase database)
         {
             if (database == null)
             {
@@ -45,9 +47,9 @@ namespace NMemory.StoredProcedures
             this.storedProcedures = new List<object>();
         }
 
-        private Database Database
+        private IDatabase Database
         {
-            get { return this.database.Target as Database; }
+            get { return this.database.Target as IDatabase; }
         }
 
         public IStoredProcedure<T> Create<T>(IQueryable<T> query)

--- a/Main/Source/NMemory/Tables/IBulkTable.cs
+++ b/Main/Source/NMemory/Tables/IBulkTable.cs
@@ -34,7 +34,7 @@ namespace NMemory.Tables
     /// Defines bulk operations for a table.
     /// </summary>
     /// <typeparam name="TEntity">The type of the entities contained by the table.</typeparam>
-    internal interface IBulkTable<TEntity>
+    public interface IBulkTable<TEntity>
         where TEntity : class
     {
         /// <summary>

--- a/Main/Source/NMemory/Tables/IRelationInternal.cs
+++ b/Main/Source/NMemory/Tables/IRelationInternal.cs
@@ -30,7 +30,7 @@ namespace NMemory.Tables
     using NMemory.Execution.Primitives;
     using NMemory.Transactions.Logs;
 
-    internal interface IRelationInternal : IRelation
+    public interface IRelationInternal : IRelation
     {
         void ValidateEntity(object foreign);
 

--- a/Main/Source/NMemory/Tables/RelationGroup.cs
+++ b/Main/Source/NMemory/Tables/RelationGroup.cs
@@ -27,7 +27,7 @@ namespace NMemory.Tables
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
 
-    internal class RelationGroup
+    public class RelationGroup
     {
         private readonly List<IRelationInternal> referring;
         private readonly List<IRelationInternal> referred;

--- a/Main/Source/NMemory/Tables/RelationKeyConverterFactory.cs
+++ b/Main/Source/NMemory/Tables/RelationKeyConverterFactory.cs
@@ -54,7 +54,9 @@ namespace NMemory.Tables
             return CreateConversion(foreignKey, primaryKey, mapping);
         }
 
-        private static Func<TFrom, TTo> CreateConversion<TFrom, TTo>(
+		#region private 
+
+		private static Func<TFrom, TTo> CreateConversion<TFrom, TTo>(
             IKeyInfo<TFrom> fromKeyInfo,
             IKeyInfo<TTo> toKeyInfo,
             int[] mapping)
@@ -154,5 +156,7 @@ namespace NMemory.Tables
 
             return helper;
         }
-    }
+		#endregion private
+
+	}
 }

--- a/Main/Source/NMemory/Tables/TableCollection.cs
+++ b/Main/Source/NMemory/Tables/TableCollection.cs
@@ -47,7 +47,7 @@ namespace NMemory.Tables
 
         private HashSet<Type> entityTypes;
 
-        internal TableCollection(IDatabase database)
+        public TableCollection(IDatabase database)
         {
             this.database = database;
             this.tables = new List<ITable>();
@@ -105,7 +105,7 @@ namespace NMemory.Tables
                 throw new ArgumentNullException("primaryKey");
             }
 
-            IKeyInfoFactory keyInfoFactory = new ModularKeyInfoFactory(this.database);
+            IKeyInfoFactory keyInfoFactory = KeyInfoFactory.ModularKeyInfoFactory(database);
 
             return this.Create(keyInfoFactory.Create(primaryKey), identitySpecification);
         }
@@ -264,21 +264,21 @@ namespace NMemory.Tables
             return this.relationMapping[foreignTable].ReferredReadOnly;
         }
 
-        internal IList<IRelationInternal> GetReferringRelations(IIndex primaryIndex)
+        public IList<IRelationInternal> GetReferringRelations(IIndex primaryIndex)
         {
             return this.GetReferringRelations(primaryIndex.Table)
                 .Where(x => x.PrimaryIndex == primaryIndex)
                 .ToList();
         }
 
-        internal IList<IRelationInternal> GetReferredRelations(IIndex foreignIndex)
+		public IList<IRelationInternal> GetReferredRelations(IIndex foreignIndex)
         {
             return this.GetReferredRelations(foreignIndex.Table)
                 .Where(x => x.ForeignIndex == foreignIndex)
                 .ToList();
         }
 
-        internal bool IsEntityType<T>()
+		public bool IsEntityType<T>()
         {
             return this.entityTypes.Contains(typeof(T));
         }

--- a/Main/Source/NMemory/Tables/Table`2.cs
+++ b/Main/Source/NMemory/Tables/Table`2.cs
@@ -490,7 +490,7 @@ namespace NMemory.Tables
             IIndexFactory indexFactory,
             Expression<Func<TEntity, TKey>> keySelector)
         {
-            var keyFactory = new ModularKeyInfoFactory(this.Database);
+            var keyFactory = KeyInfoFactory.ModularKeyInfoFactory(Database);
             var key = keyFactory.Create(keySelector);
             var index = indexFactory.CreateIndex(this, key);
 
@@ -528,7 +528,7 @@ namespace NMemory.Tables
         /// <param name="indexFactory">
         ///     The index factory.
         /// </param>
-        /// <param name="key">
+		/// <param name="keySelector">
         ///     The expression representing the definition of the index key.
         /// </param>
         /// <returns>
@@ -538,7 +538,7 @@ namespace NMemory.Tables
             IIndexFactory indexFactory,
             Expression<Func<TEntity, TUniqueKey>> keySelector)
         {
-            var keyFactory = new ModularKeyInfoFactory(this.Database);
+			var keyFactory = KeyInfoFactory.ModularKeyInfoFactory(Database);
             var key = keyFactory.Create(keySelector);
             var index = indexFactory.CreateUniqueIndex(this, key);
 

--- a/Main/Source/NMemory/Transactions/Transaction.cs
+++ b/Main/Source/NMemory/Transactions/Transaction.cs
@@ -53,7 +53,7 @@ namespace NMemory.Transactions
             return new Transaction(external, false);
         }
 
-        internal static TransactionContext EnsureTransaction(ref Transaction transaction, IDatabase database)
+        public static TransactionContext EnsureTransaction(ref Transaction transaction, IDatabase database)
         {
             TransactionContext result = null;
 
@@ -83,7 +83,7 @@ namespace NMemory.Transactions
             return result;
         }
 
-        internal static Transaction TryGetAmbientEnlistedTransaction()
+        public static Transaction TryGetAmbientEnlistedTransaction()
         {
             System.Transactions.Transaction ambientTransaction = System.Transactions.Transaction.Current;
 
@@ -119,7 +119,7 @@ namespace NMemory.Transactions
 
         private HashSet<ITransactionHandler> registeredHandlers;
 
-        internal Transaction(System.Transactions.Transaction transaction, bool isAmbient)
+        public Transaction(System.Transactions.Transaction transaction, bool isAmbient)
         {
             this.internalTransaction = transaction;
             this.isAmbient = isAmbient;
@@ -182,7 +182,7 @@ namespace NMemory.Transactions
             }
         }
 
-        internal void EnterAtomicSection()
+        public void EnterAtomicSection()
         {
             this.atomicSectionLock.Enter();
 
@@ -193,7 +193,7 @@ namespace NMemory.Transactions
             }
         }
 
-        internal void ExitAtomicSection()
+		public void ExitAtomicSection()
         {
             this.atomicSectionLock.Exit();
         }

--- a/Main/Source/NMemory/Utilities/TableExtensions.cs
+++ b/Main/Source/NMemory/Utilities/TableExtensions.cs
@@ -31,7 +31,7 @@ namespace NMemory.Utilities
 
     public static class TableExtensions
     {
-        internal static IEnumerable<T> SelectAll<T>(this ITable<T> table)
+		public static IEnumerable<T> SelectAll<T>(this ITable<T> table)
             where T : class
         {
             if (table == null)


### PR DESCRIPTION
… the major Implementations to improve architectural boundaries and prepare easier .

Unfortunately had to separate out ModularKeyInfoFactory Constructor into a Delegate that is registered in the static Constructor of Database.cs. Otherwise most of the Implementations would have ended up in the interface project. You can probably find a better way to inject this functionality, for now it is sufficient to have the project working with all tests green. 

You prepared this separation quite well by using interfaces for most implementations, but by putting all into a single project, the arcitectural boundaries are unclear and diluted. I hope I found a proper line to separate both. You might have had a different Separation in mind. This seemed to create the least coupling. I usually split my projects into three parts: 
- Interfaces, Data containers & Extension Methods 
- Default Interface Implementations 
- one project for each major Implementation Variant 

Regards...
Matthias
